### PR TITLE
Fixed build for modern macOS and GCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore backup files of common text editors:
+**/*~
+# Ignore macOS Desktop Services Store configuration files:
+**/.DS_Store
+# Ignore generated object and binary directories:
+ypsilon
+**/*.d
+**/*.o

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ $(PROG): $(OBJS)
 
 vm1.s: vm1.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) \
-	-fno-reorder-blocks -fno-crossjumping -fno-align-labels -fno-align-loops -fno-align-jumps \
+	-fno-reorder-blocks -fno-align-labels -fno-align-loops -fno-align-jumps \
 	-fverbose-asm -masm=att -S src/vm1.cpp
 
 SDLMain.dylib: SDLMain.m
@@ -264,7 +264,7 @@ SDLMain.dylib: SDLMain.m
 
 vm1.o: vm1.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) \
-	-fno-reorder-blocks -fno-crossjumping -fno-align-labels -fno-align-loops -fno-align-jumps \
+	-fno-reorder-blocks -fno-align-labels -fno-align-loops -fno-align-jumps \
 	-c src/vm1.cpp
 
 install: all stdlib sitelib extension

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
+**NOTE:** This fork of _Ypsilon_ contains a build-fix for _macOS_ version 10.13.6 (_macOS High Sierra_). With the fix, a working _Ypsilon_ can be build using _GCC_ 9.2.0 or _Apple LLVM_ version 10.0.0 (_clang_ 1000.10.44.4).
+
 # Ypsilon
 
 ## Overview


### PR DESCRIPTION
Fixed build bug for macOS (version 10.13.6, macOS High Sierra). Ypsilon can now be build with GCC 9.2.0 or Apple LLVM version 10.0.0 (clang 1000.10.44.4).

Also added a `.gitignore` file to avoid commits of generated artefacts.